### PR TITLE
Change DeviceListApiModel to use Pascal Case

### DIFF
--- a/app/com/microsoft/azure/iotsolutions/uiconfig/services/external/DeviceListApiModel.java
+++ b/app/com/microsoft/azure/iotsolutions/uiconfig/services/external/DeviceListApiModel.java
@@ -13,7 +13,7 @@ public class DeviceListApiModel {
 
     private List<DeviceRegistryApiModel> items;
 
-    @JsonProperty("items")
+    @JsonProperty("Items")
     public List<DeviceRegistryApiModel> getItems() {
         return items;
     }

--- a/test/com/microsoft/azure/iotsolutions/uiconfig/services/IothubManagerServiceClientTest.java
+++ b/test/com/microsoft/azure/iotsolutions/uiconfig/services/IothubManagerServiceClientTest.java
@@ -28,7 +28,7 @@ public class IothubManagerServiceClientTest {
     private IHttpClient mockHttpClient;
     private IothubManagerServiceClient client;
     private String content = "{" +
-            "  \"items\": [" +
+            "  \"Items\": [" +
             "    {" +
             "      \"Properties\": {" +
             "        \"Reported\": {" +


### PR DESCRIPTION
This commit dependends on the PR of using Pascal Case for Json properties
of this model in iothub-manager-java

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

This work will eliminate inconsistency of Json property naming and use Pascal Case for DeviceListApiModel. It depends on the PR [#81](https://github.com/Azure/iothub-manager-java/pull/81).

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
